### PR TITLE
Fix multi-layer optimization and broken links

### DIFF
--- a/src/GAMMA/README.md
+++ b/src/GAMMA/README.md
@@ -13,7 +13,7 @@ In the basic usage, Gamma will create a map space assuming full flexibility in t
 * l2_size: L2 size (Number of elements)
 * slevel_min: The minimum number of parallelism
 * slevel_max: The maximum number of parallelism. The number of parallelism will be in the range [slevel_min, slevel_max]
-* hwconfig: Read in HW configuration from file. An example of hwconfig can be found [here](data/HWconfigs/hw_config.m). An example of using it can be found [here](../run_gamma_with_hwconfig.sh)
+* hwconfig: Read in HW configuration from file. An example of hwconfig can be found [here](../../data/HWconfigs/hw_config.m). An example of using it can be found [here](../../run_gamma_with_hwconfig.sh)
 * epochs: Number of generation for the optimization
 * outdir: The output result directory
 

--- a/src/GAMMA/main.py
+++ b/src/GAMMA/main.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     parser.add_argument('--offchipBW', type=int, default=-1, help='Off-chip BW')
     parser.add_argument('--hwconfig', type=str, default=None, help='HW configuration file')
     parser.add_argument('--model', type=str, default="resnet18", help='Model to run')
-    parser.add_argument('--num_layer', type=int, default=2, help='Number of layers to optimize')
+    parser.add_argument('--num_layer', type=int, default=0, help='Number of layers to optimize')
     parser.add_argument('--singlelayer', type=int, default=0, help='The layer index to optimize')
     parser.add_argument('--slevel_min', type=int, default=2, help='Minimum number of parallelization level')
     parser.add_argument('--slevel_max', type=int, default=2, help='Maximum number of parallelization level')


### PR DESCRIPTION
We cannot save a proper result_c.csv/plt for multi-layer optimization when we skip `--singlelayer` because of the following reasons:
1. Users might not be aware of  `--num_layer` since it isn't listed in the [README.md (Basic Usage)](https://github.com/maestro-project/gamma/tree/master/src/GAMMA#basic-usage). Also, the [default value of it is 2](https://github.com/maestro-project/gamma/blob/3d6caf8448b269fa25c2f224db97fcc470d0370f/src/GAMMA/main.py#L18) which means optimizing the first two layers.
2. [These lines](https://github.com/maestro-project/gamma/blob/3d6caf8448b269fa25c2f224db97fcc470d0370f/src/GAMMA/train.py#L93-L95) overwrite the existing csv and plt file, so we can only save the last single-layer result.

I address these problems and fix some broken links in the [README.md](https://github.com/maestro-project/gamma/tree/master/src/GAMMA#readme) in this pull request.